### PR TITLE
Support order and except attributes simultaneously

### DIFF
--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -564,10 +564,10 @@ class FormFieldsTagLib {
 		List<PersistentProperty> properties
 
 		if (attrs.order) {
-			if (attrs.except) {
-				throwTagError('The [except] and [order] attributes may not be used together.')
-			}
 			def orderBy = getList(attrs.order)
+			if (attrs.except) {
+				orderBy = orderBy - getList(attrs.except)
+			}
 			properties = orderBy.collect { propertyName ->
 				fieldsDomainPropertyFactory.build(domainClass.getPropertyByName(propertyName))
 			}

--- a/src/test/groovy/grails/plugin/formfields/taglib/AllTagSpec.groovy
+++ b/src/test/groovy/grails/plugin/formfields/taglib/AllTagSpec.groovy
@@ -86,18 +86,17 @@ class AllTagSpec extends AbstractFormFieldsTagLibSpec implements TagLibUnitTest<
 
     }
 
-    @Issue('https://github.com/grails3-plugins/fields/issues/9')
-    void 'order attribute and except attribute are mutually exclusive'() {
+    @Issue('https://github.com/gpc/fields/issues/347')
+    void 'allow order and except attributes'() {
         given:
         views["/_fields/default/_field.gsp"] = '|${property}|'
         views["/_fields/default/_wrapper.gsp"] = '${widget}'
 
         when:
-        applyTemplate('<f:all bean="personInstance" except="password" order="name, minor, gender"/>', [personInstance: personInstance])
+        def output = applyTemplate('<f:all bean="personInstance" except="minor, password" order="name, minor, gender"/>', [personInstance: personInstance])
 
         then:
-        GrailsTagException e = thrown()
-        e.message.contains 'The [except] and [order] attributes may not be used together.'
+        output == '|name||gender|'
     }
 
     void "f:all tag supports theme"() {


### PR DESCRIPTION
There is no reason to not allow order + except as long as except takes precedence.

```gsp
<f:all bean="user" order="id,firstName,lastName,password" except="${fullyAuthenticated?'password':''}"/>
```

This change allows both and removes any except parameters from order.