### PR TITLE
Allow customization of default wrapper in order to support Bootstrap without requiring templates

### DIFF
--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -168,6 +168,9 @@ class FormFieldsTagLib {
 	 * @attr widget Specify the folder inside _fields where to look up for the widget template.
 	 * @attr templates Specify the folder inside _fields where to look up for the wrapper and widget template.
 	 * @attr theme Theme name
+	 * @attr divClass class for optional div that will be added if set and contain the widget
+	 * @attr invalidClass class added to wrapper that if property is invalid. Also available for widget.
+	 * @attr requiredClass class added to wrapper when property is required. Also available for widget.
 	 */
 	def field = { attrs, body ->
 		attrs = beanStack.innerAttributes + attrs

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -168,9 +168,10 @@ class FormFieldsTagLib {
 	 * @attr widget Specify the folder inside _fields where to look up for the widget template.
 	 * @attr templates Specify the folder inside _fields where to look up for the wrapper and widget template.
 	 * @attr theme Theme name
-	 * @attr divClass class for optional div that will be added if set and contain the widget
-	 * @attr invalidClass class added to wrapper that if property is invalid. Also available for widget.
-	 * @attr requiredClass class added to wrapper when property is required. Also available for widget.
+	 * @attr css html css attribute for wrapper (default: field-contain)
+	 * @attr divClass class for optional div that will be added if set and contain the widget (default: no div created)
+	 * @attr invalidClass class added to wrapper that if property is invalid. (default: error) Also available for widget.
+	 * @attr requiredClass class added to wrapper when property is required. (default: required) Also available for widget.
 	 */
 	def field = { attrs, body ->
 		attrs = beanStack.innerAttributes + attrs

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -343,7 +343,7 @@ class FormFieldsTagLib {
 				String template = attrs.remove('template') ?: 'list'
 
 				List properties = resolvePersistentProperties(domainClass, attrs)
-				out << render(template: "/templates/_fields/$template", model: [domainClass: domainClass, domainProperties: properties]) { prop ->
+				out << render(template: "/templates/_fields/$template", model: attrs + [domainClass: domainClass, domainProperties: properties]) { prop ->
 					BeanPropertyAccessor propertyAccessor = resolveProperty(bean, prop.name)
 					Map model = buildModel(propertyAccessor, attrs, 'HTML')
 					out << raw(renderDisplayWidget(propertyAccessor, model, attrs, templatesFolder, theme))

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -20,6 +20,7 @@ import grails.core.GrailsApplication
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import groovy.xml.MarkupBuilder
+import groovy.xml.MarkupBuilderHelper
 import org.apache.commons.lang.StringUtils
 import org.grails.buffer.FastStringWriter
 import org.grails.datastore.mapping.model.MappingContext
@@ -190,15 +191,16 @@ class FormFieldsTagLib {
 
 			String prefixAttribute = formFieldsTemplateService.getWidgetPrefix() ?: 'widget-'
 			attrs.each { k, v ->
-				if (k?.startsWith(prefixAttribute))
+				if (k?.startsWith(prefixAttribute)) {
 					widgetAttrs[k.replace(prefixAttribute, '')] = v
-				else
+				} else {
 					wrapperAttrs[k] = v
+				}
 			}
 
-			List classes = [widgetAttrs['class']?:'']
-			if (model.invalid) classes << (widgetAttrs.remove('invalidClass')?:'')
-			if (model.required) classes << (widgetAttrs.remove('requiredClass')?:'')
+			List classes = [widgetAttrs['class'] ?: '']
+			if (model.invalid) classes << (widgetAttrs.remove('invalidClass') ?: '')
+			if (model.required) classes << (widgetAttrs.remove('requiredClass') ?: '')
 			widgetAttrs['class'] = classes.join(' ').trim()
 			if (widgetAttrs['class'].isEmpty()) {
 				widgetAttrs.remove('class')
@@ -361,10 +363,11 @@ class FormFieldsTagLib {
 
 			String prefixAttribute = formFieldsTemplateService.getWidgetPrefix() ?: 'widget-'
 			attrs.each { k, v ->
-				if (k?.startsWith(prefixAttribute))
+				if (k?.startsWith(prefixAttribute)) {
 					widgetAttrs[k.replace(prefixAttribute, '')] = v
-				else
+				} else {
 					wrapperAttrs[k] = v
+				}
 			}
 
 
@@ -394,8 +397,9 @@ class FormFieldsTagLib {
 		Map widgetAttrs = [:]
 		attrs.each { k, v ->
 			String prefixAttribute = formFieldsTemplateService.getWidgetPrefix()
-			if (k?.startsWith(prefixAttribute))
+			if (k?.startsWith(prefixAttribute)) {
 				widgetAttrs[k.replace(prefixAttribute, '')] = v
+			}
 		}
 		return widgetAttrs
 	}
@@ -430,11 +434,9 @@ class FormFieldsTagLib {
 	private List<String> resolvePropertyNames(PersistentEntity domainClass, Map attrs) {
 		if (attrs.containsKey('order')) {
 			return getList(attrs.order)
-		}
-		else if (attrs.containsKey('properties')) {
+		} else if (attrs.containsKey('properties')) {
 			return getList(attrs.remove('properties'))
 		} else {
-
 			List<String> properties = resolvePersistentProperties(domainClass, attrs, true)*.name
 			int maxProperties = attrs.containsKey('maxProperties') ? attrs.remove('maxProperties').toInteger() : 7
 			if (maxProperties && properties.size() > maxProperties) {
@@ -479,8 +481,7 @@ class FormFieldsTagLib {
 				String errorMsg = null
 				try {
 					errorMsg = error instanceof MessageSourceResolvable ? messageSource.getMessage(error, locale) : messageSource.getMessage(error.toString(), null, locale)
-				}
-				catch (NoSuchMessageException ignored) {
+				} catch (NoSuchMessageException ignored) {
 					// no-op
 				}
 				// unresolved message codes fallback to the defaultMessage and this should
@@ -546,8 +547,9 @@ class FormFieldsTagLib {
 
 	private String resolvePrefix(prefixAttribute) {
 		def prefix = resolvePageScopeVariable(prefixAttribute) ?: prefixAttribute ?: beanStack.prefix
-		if (prefix && !prefix.endsWith('.'))
+		if (prefix && !prefix.endsWith('.')) {
 			prefix = prefix + '.'
+		}
 		prefix ?: ''
 	}
 
@@ -622,16 +624,16 @@ class FormFieldsTagLib {
 		def message = keysInPreferenceOrder.findResult { key ->
 			message(code: key, default: null) ?: null
 		}
-		if(log.traceEnabled && !message) {
+		if (log.traceEnabled && !message) {
 			log.trace("i18n missing translation for one of ${keysInPreferenceOrder}")
 		}
 		message ?: defaultMessage
 	}
 
 	protected CharSequence renderDefaultField(Map model, Map attrs = [:]) {
-		List classes = [attrs['class']?:'fieldcontain']
-		if (model.invalid) classes << (attrs.remove('invalidClass')?:'error')
-		if (model.required) classes << (attrs.remove('requiredClass')?:'required')
+		List classes = [attrs['class'] ?: 'fieldcontain']
+		if (model.invalid) classes << (attrs.remove('invalidClass') ?: 'error')
+		if (model.required) classes << (attrs.remove('requiredClass') ?: 'required')
 		attrs['class'] = classes.join(' ').trim()
 		Writer writer = new FastStringWriter()
 		def mb = new MarkupBuilder(writer)
@@ -653,7 +655,7 @@ class FormFieldsTagLib {
 		writer.buffer
 	}
 
-	private void renderWidget(def mkp, Map model) {
+	private void renderWidget(MarkupBuilderHelper mkp, Map model) {
 		// TODO: encoding information of widget gets lost - don't use MarkupBuilder
 		def widget = model.widget
 		if (widget != null) {
@@ -729,18 +731,24 @@ class FormFieldsTagLib {
 		if (!attrs.type) {
 			if (constrained?.inList) {
 				attrs.from = constrained.inList
-				if (!model.required) attrs.noSelection = ["": ""]
+				if (!model.required) {
+					attrs.noSelection = ["": ""]
+				}
 				return g.select(attrs)
 			} else if (constrained?.password) {
 				attrs.type = "password"
 				attrs.remove('value')
-			} else if (constrained?.email) attrs.type = "email"
-			else if (constrained?.url) attrs.type = "url"
-			else attrs.type = "text"
+			} else if (constrained?.email) {
+				attrs.type = "email"
+			} else if (constrained?.url) {
+				attrs.type = "url"
+			} else {
+				attrs.type = "text"
+			}
 		}
 
-		if (constrained?.matches) attrs.pattern = constrained.matches
-		if (constrained?.maxSize) attrs.maxlength = constrained.maxSize
+		if (constrained?.matches) { attrs.pattern = constrained.matches }
+		if (constrained?.maxSize) { attrs.maxlength = constrained.maxSize }
 
 		if (constrained?.widget == 'textarea') {
 			attrs.remove('type')

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -197,8 +197,8 @@ class FormFieldsTagLib {
 			}
 
 			List classes = [widgetAttrs['class']?:'']
-			if (model.invalid) classes << (widgetAttrs.remove('invalidClass')?:'error')
-			if (model.required) classes << (widgetAttrs.remove('requiredClass')?:'required')
+			if (model.invalid) classes << (widgetAttrs.remove('invalidClass')?:'')
+			if (model.required) classes << (widgetAttrs.remove('requiredClass')?:'')
 			widgetAttrs['class'] = classes.join(' ').trim()
 			if (widgetAttrs['class'].isEmpty()) {
 				widgetAttrs.remove('class')
@@ -214,7 +214,7 @@ class FormFieldsTagLib {
 			if (template) {
 				out << render(template: template.path, plugin: template.plugin, model: model + [attrs: wrapperAttrs] + wrapperAttrs)
 			} else {
-				out << renderDefaultField(wrapperAttrs, model)
+				out << renderDefaultField(model, wrapperAttrs)
 			}
 		}
 	}
@@ -628,7 +628,7 @@ class FormFieldsTagLib {
 		message ?: defaultMessage
 	}
 
-	private CharSequence renderDefaultField(Map attrs, Map model) {
+	protected CharSequence renderDefaultField(Map model, Map attrs = [:]) {
 		List classes = [attrs['class']?:'fieldcontain']
 		if (model.invalid) classes << (attrs.remove('invalidClass')?:'error')
 		if (model.required) classes << (attrs.remove('requiredClass')?:'required')

--- a/grails-app/views/templates/_fields/_list.gsp
+++ b/grails-app/views/templates/_fields/_list.gsp
@@ -1,8 +1,8 @@
-<ol class="property-list ${domainClass.decapitalizedName}">
+<ol class="${listClass?:'property-list'} ${domainClass.decapitalizedName}">
     <g:each in="${domainProperties}" var="p">
-        <li class="fieldcontain">
-            <span id="${p.name}-label" class="property-label"><g:message code="${domainClass.decapitalizedName}.${p.name}.label" default="${p.defaultLabel}" /></span>
-            <div class="property-value" aria-labelledby="${p.name}-label">${body(p)}</div>
+        <li class="${listItemClass?:'fieldcontain'}">
+            <span id="${p.name}-label" class="${labelClass?:'property-label'}"><g:message code="${domainClass.decapitalizedName}.${p.name}.label" default="${p.defaultLabel}" /></span>
+            <div class="${valueClass?:'property-value'}" aria-labelledby="${p.name}-label">${body(p)}</div>
         </li>
     </g:each>
 </ol>

--- a/grails-app/views/templates/_fields/_list.gsp
+++ b/grails-app/views/templates/_fields/_list.gsp
@@ -1,4 +1,4 @@
-<ol class="${listClass?:'property-list'} ${domainClass.decapitalizedName}">
+<ol class="${pageScope['class']?:'property-list'} ${domainClass.decapitalizedName}">
     <g:each in="${domainProperties}" var="p">
         <li class="${listItemClass?:'fieldcontain'}">
             <span id="${p.name}-label" class="${labelClass?:'property-label'}"><g:message code="${domainClass.decapitalizedName}.${p.name}.label" default="${p.defaultLabel}" /></span>

--- a/grails-app/views/templates/_fields/_table.gsp
+++ b/grails-app/views/templates/_fields/_table.gsp
@@ -1,4 +1,4 @@
-<table>
+<table<g:if test="${pageScope['class']}"> class="${pageScope['class']}"</g:if>>
     <thead>
          <tr>
             <g:each in="${domainProperties}" var="p" status="i">
@@ -11,10 +11,10 @@
             <tr class="${(i % 2) == 0 ? 'even' : 'odd'}">
                 <g:each in="${domainProperties}" var="p" status="j">
                     <g:if test="${j==0}">
-                        <td><g:link method="GET" resource="${bean}"><f:display bean="${bean}" property="${p.property}" displayStyle="${displayStyle?:'table'}" theme="${theme}"/></g:link></td>
+                        <td><g:link method="GET" resource="${bean}" controller="${controller}"><f:display bean="${bean}" property="${p.property}" displayStyle="${displayStyle?:'table'}" theme="${theme}"/></g:link></td>
                     </g:if>
                     <g:else>
-                        <td><f:display bean="${bean}" property="${p.property}"  displayStyle="${displayStyle?:'table'}" theme="${theme}"/></td>
+                        <td><f:display bean="${bean}" property="${p.property}" displayStyle="${displayStyle?:'table'}" theme="${theme}"/></td>
                     </g:else>
                 </g:each>
             </tr>


### PR DESCRIPTION
# This Objective
Reduce the amount of code in generate-app to the least amount possible while still maintaining readability and structure. 

## It is here for review and feedback

1. Modify <f:all /> - Complete
```gsp
<f:all bean="domain" class="row mb-3" labelClass="col-sm-2 col-form-label text-sm-end" divClass="col-sm-10" invalidClass="" requiredClass="" widget-class="form-control" widget-invalidClass="is-invalid" />
```

Design Decisions:  `<li><label></label><div>widget</div></li>` pattern is needed.  To maintain backwards compatibility, the div is only injected if the `divClass` attribute is present. 

2. Modify [<f:table collection="domainList"/>](https://github.com/gpc/fields/blob/master/grails-app/views/templates/_fields/_table.gsp)

```gsp
<f:table class="table table-striped table-sm" controller="${controllerName}" collection="${sampleList}" />
```

3. Modify [<f:display bean="domain" />](https://github.com/gpc/fields/blob/master/grails-app/views/templates/_fields/_list.gsp)

```gsp
<f:display bean="sample" class="container" listItemClass="row mb-3" labelClass="form-label col-sm-3 text-sm-end" valueClass="col-sm-9" />
```