### PR TITLE
Exclude org.codehaus.groovy:2.4.6 from groovydoc-gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,10 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath 'io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1'
-        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
-    }
-
-    configurations.configureEach {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            if ((details.requested.group == 'org.codehaus.groovy' || details.requested.group == 'org.apache.groovy') && details.requested.name != 'groovy-bom') {
-                details.useTarget(group: 'org.codehaus.groovy', name: details.requested.name, version: "$GroovySystem.version")
-                details.because "Use version of Groovy provided by Gradle"
-            }
+        classpath 'io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1', {
+            exclude group:'org.codehaus.groovy'
         }
+        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
     }
 }
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,15 @@ buildscript {
         classpath 'io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1'
         classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
     }
+
+    configurations.configureEach {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if ((details.requested.group == 'org.codehaus.groovy' || details.requested.group == 'org.apache.groovy') && details.requested.name != 'groovy-bom') {
+                details.useTarget(group: 'org.codehaus.groovy', name: details.requested.name, version: "$GroovySystem.version")
+                details.because "Use version of Groovy provided by Gradle"
+            }
+        }
+    }
 }
 plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'


### PR DESCRIPTION
Resolves the following:

```
A problem occurred configuring root project 'fields'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.codehaus.groovy:groovy-groovydoc:2.4.6.
     Required by:
         root project : > io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1
      > Module 'org.codehaus.groovy:groovy-groovydoc' has been rejected:
           Cannot select module with conflict on capability 'org.codehaus.groovy:groovy-groovydoc:2.4.6' also provided by [org.apache.groovy:groovy-groovydoc:4.0.22(groovyRuntimeElements)]
   > Could not resolve org.apache.groovy:groovy:4.0.22.
     Required by:
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33 > org.apache.groovy:groovy-ant:4.0.22
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33 > org.apache.groovy:groovy-json:4.0.22
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33 > org.apache.groovy:groovy-jmx:4.0.22
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33 > org.apache.groovy:groovy-ant:4.0.22 > org.apache.groovy:groovy-bom:4.0.22
      > Module 'org.apache.groovy:groovy' has been rejected:
           Cannot select module with conflict on capability 'org.codehaus.groovy:groovy:4.0.22' also provided by [org.codehaus.groovy:groovy:2.4.6(runtime)]
   > Could not resolve org.codehaus.groovy:groovy:2.4.6.
     Required by:
         root project : > io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1 > org.codehaus.groovy:groovy-groovydoc:2.4.6
         root project : > io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1 > org.codehaus.groovy:groovy-groovydoc:2.4.6 > org.codehaus.groovy:groovy-templates:2.4.6
         root project : > io.github.groovylang.groovydoc:groovydoc-gradle-plugin:1.0.1 > org.codehaus.groovy:groovy-groovydoc:2.4.6 > org.codehaus.groovy:groovy-templates:2.4.6 > org.codehaus.groovy:groovy-xml:2.4.6
      > Module 'org.codehaus.groovy:groovy' has been rejected:
           Cannot select module with conflict on capability 'org.codehaus.groovy:groovy:2.4.6' also provided by [org.apache.groovy:groovy:4.0.22(groovyRuntimeElements)]
   > Could not resolve org.apache.groovy:groovy-groovydoc:4.0.22.
     Required by:
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33 > org.apache.groovy:groovy-ant:4.0.22
         root project : > org.grails:grails-gradle-plugin:7.0.0-SNAPSHOT:20240918.041752-18 > org.grails:grails-shell:7.0.0-SNAPSHOT:20240917.014737-33 > org.apache.groovy:groovy-ant:4.0.22 > org.apache.groovy:groovy-bom:4.0.22
      > Module 'org.apache.groovy:groovy-groovydoc' has been rejected:
           Cannot select module with conflict on capability 'org.codehaus.groovy:groovy-groovydoc:4.0.22' also provided by [org.codehaus.groovy:groovy-groovydoc:2.4.6(runtime)]

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
BUILD FAILED in 265ms
```