### PR TITLE
Proper formatting of checkbox for bootstrap 5

### DIFF
--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -700,9 +700,19 @@ class FormFieldsTagLib {
 			}
 		}
 
+		boolean dateWidget = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime]
+		if (!dateWidget) {
+			attrs.remove('selectDateClass')
+		}
+		boolean checkBox = model.type in [boolean, Boolean]
+		String checkBoxClass = attrs.remove('checkBoxClass')
+		if (checkBox && checkBoxClass) {
+			attrs['class'] = checkBoxClass
+		}
+
 		if (model.type in [String, null]) {
 			return renderStringInput(model, attrs)
-		} else if (model.type in [boolean, Boolean]) {
+		} else if (checkBox) {
 			return g.checkBox(attrs)
 		} else if (model.type.isPrimitive() || model.type in Number) {
 			return renderNumericInput(propertyAccessor, model, attrs)
@@ -714,7 +724,7 @@ class FormFieldsTagLib {
 			return renderAssociationInput(model, attrs)
 		} else if (oneToMany) {
 			return renderOneToManyInput(model, attrs)
-		} else if (model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime]) {
+		} else if (dateWidget) {
 			return renderDateTimeInput(model, attrs)
 		} else if (model.type in [byte[], Byte[], Blob]) {
 			return g.field(attrs + [type: "file"])

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -700,8 +700,8 @@ class FormFieldsTagLib {
 			}
 		}
 
-		boolean dateWidget = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime]
-		if (!dateWidget) {
+		boolean datePicker = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime]
+		if (!datePicker) {
 			attrs.remove('selectDateClass')
 		}
 		boolean checkBox = model.type in [boolean, Boolean]
@@ -724,7 +724,7 @@ class FormFieldsTagLib {
 			return renderAssociationInput(model, attrs)
 		} else if (oneToMany) {
 			return renderOneToManyInput(model, attrs)
-		} else if (dateWidget) {
+		} else if (datePicker) {
 			return renderDateTimeInput(model, attrs)
 		} else if (model.type in [byte[], Byte[], Blob]) {
 			return g.field(attrs + [type: "file"])

--- a/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/formfields/FormFieldsTagLib.groovy
@@ -700,6 +700,7 @@ class FormFieldsTagLib {
 			}
 		}
 
+		// TODO: https://github.com/gpc/fields/issues/392
 		boolean datePicker = model.type in [Date, Calendar, java.sql.Date, java.sql.Time, LocalDate, LocalDateTime]
 		if (!datePicker) {
 			attrs.remove('selectDateClass')


### PR DESCRIPTION
Currently check boxes display horribly.  The main issue is with the `<f:all`  tag not having a clean way of passing styling attributes to specific widgets.  

This PR allows:

```html
<f:all bean="${propertyName}" class="row" requiredClass="mb-3 required" labelClass="col-sm-2 col-form-label text-sm-end" divClass="col-sm-10" widget-selectDateClass="w-auto form-select d-inline" widget-class="form-control" widget-checkBoxClass="form-check-input align-middle"  widget-invalidClass="is-invalid" />
```

Specifically
```
widget-selectDateClass="w-auto form-select d-inline"  widget-checkBoxClass="form-check-input align-middle"
```

Does 2 things.  

1. removes `selectDateClass` from attrs for other widgets.
2. Allows passing of classes necessary to format check boxes correctly.

Should  later be refined via https://github.com/gpc/fields/issues/392