### PR TITLE
ci: add `GITHUB_MAVEN_PASSWORD` to build step in `gradle.yml`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,6 +30,8 @@ jobs:
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
       - name: "🔨 Run Build"
+        env:
+          GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew build
   publish:
     if: github.event_name == 'push'


### PR DESCRIPTION
Otherwise, the build fails during a Grails release before the artifacts are published to maven central